### PR TITLE
Update README.md for Android instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and on Android you can pass a `Context` to create the file in the app's database
 Database(
   AndroidxSqliteDriver(
     driver = BundledSQLiteDriver(),
-    type = AndroidxSqliteDatabaseType.File(context, "my.db"),
+    type = AndroidxSqliteDatabaseType.FileProvider(context, "my.db"),
     schema = Database.Schema,
   )
 )


### PR DESCRIPTION
An extremely minor fix for README.md caused by #107 changing from `AndroidxSqliteDatabaseType.File` to `AndroidxSqliteDatabaseType.FileProvider`. Thanks!