### PR TITLE
:opfs-driver: pass ignoreDefaultTargets to kmpTargets

### DIFF
--- a/opfs-driver/build.gradle.kts
+++ b/opfs-driver/build.gradle.kts
@@ -5,10 +5,16 @@ plugins {
 }
 
 kotlin {
+  // ignoreDefaultTargets = true so the project's default KMP targets (Android, iOS,
+  // JVM, etc.) are excluded — opfs-driver only ships JS and wasmJs. Without this flag the
+  // conventions plugin's kmpTargets call additively merges with the root defaults, leaving
+  // every other target wired up but with no source — which the snapshot publish then
+  // chokes on because the iosArm64 klib (etc.) was never produced.
   kmpTargets(
     KmpTarget.Js,
     KmpTarget.WasmJs,
     project = project,
+    ignoreDefaultTargets = true,
   )
 
   sourceSets {

--- a/opfs-driver/build.gradle.kts
+++ b/opfs-driver/build.gradle.kts
@@ -5,11 +5,6 @@ plugins {
 }
 
 kotlin {
-  // ignoreDefaultTargets = true so the project's default KMP targets (Android, iOS,
-  // JVM, etc.) are excluded — opfs-driver only ships JS and wasmJs. Without this flag the
-  // conventions plugin's kmpTargets call additively merges with the root defaults, leaving
-  // every other target wired up but with no source — which the snapshot publish then
-  // chokes on because the iosArm64 klib (etc.) was never produced.
   kmpTargets(
     KmpTarget.Js,
     KmpTarget.WasmJs,


### PR DESCRIPTION
## Summary
- Fixes the snapshot-publish failure introduced by adding the `web` branch to `publish_snapshot_release.yml` ([failed run](https://github.com/eygraber/sqldelight-androidx-driver/actions/runs/24980751441/job/73142162577)).
- The conventions plugin's `kmpTargets(...)` call additively merges with the root `gradleConventionsKmpDefaults.targets(...)` unless `ignoreDefaultTargets = true` is passed. Without it, `:opfs-driver` was being wired up for every default KMP target (Android, iOS, Linux, macOS, tvOS, watchOS, JVM) even though it only has `webMain` source.
- That mismatch wasn't caught until now because `:opfs-driver` is new on the `web` branch and the snapshot-publish trigger only started running against `web` in #215. `generateMetadataFileForIosArm64Publication` blew up because the `iosArm64` klib was never produced (`compileKotlinIosArm64` was NO-SOURCE).

## Test plan
- [x] `./gradlew :opfs-driver:publishToMavenLocal` succeeds locally
- [x] `./gradlew detektAll allTests` is green
- [ ] CI snapshot publish on the web branch comes up green after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)