### PR TITLE
README: point readers to the web alpha branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The SQLDelight AndroidX Driver provides a [SQLDelight] driver that wraps [Androi
 * [SQLDelight docs]
 * [Set up SQLite for KMP]
 
+> [!TIP]
+> Interested in trying out web (`wasmJs` / `js`) support? An alpha is in progress on the [`web`](https://github.com/eygraber/sqldelight-androidx-driver/tree/web) branch — feedback welcome.
+
 ## Migrating from the pre-async version of the driver
 
 > [!NOTE]  


### PR DESCRIPTION
## Summary
- Add a short tip in the README directing users interested in `wasmJs` / `js` support to the in-progress alpha on the [`web`](https://github.com/eygraber/sqldelight-androidx-driver/tree/web) branch.

## Test plan
- [x] Render preview of README on GitHub looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)