### PR TITLE
Prevent writerMutex deadlock due to CancellationException

### DIFF
--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
@@ -45,23 +45,28 @@ internal class AndroidxSqliteExecutingDriver(
   override suspend fun <R> dispatch(transaction: suspend () -> R) =
     when(val enclosing = currentCoroutineContext()[TransactionElement]) {
       null -> {
-        val writer = connectionPool.acquireWriterConnection()
-        // The Transaction's endTransaction path releases the writer once BEGIN IMMEDIATE succeeds.
-        // Before that — e.g. a cancellation during the dispatcher switch, a throw before the
-        // runBlocking coroutine is set up, or BEGIN IMMEDIATE itself throwing — the release is
-        // owned by this call site. released=true suppresses the fallback once ownership transfers
-        // to the Transaction.
-        var released = false
-        try {
-          startTransactionCoroutine(
-            writeConnection = writer,
-            block = transaction,
-            onTransactionStarted = { released = true },
-          )
-        }
-        finally {
-          if(!released) {
-            withContext(NonCancellable) {
+        val outerContext = currentCoroutineContext()
+        // Wrap acquire/release in NonCancellable to prevent CancellationException from deadlocking
+        // the mutex. outerContext is restored inside so the transaction body remains cancellable.
+        withContext(NonCancellable) {
+          val writer = connectionPool.acquireWriterConnection()
+          // The Transaction's endTransaction path releases the writer once BEGIN IMMEDIATE succeeds.
+          // Before that — e.g. a cancellation during the dispatcher switch, a throw before the
+          // runBlocking coroutine is set up, or BEGIN IMMEDIATE itself throwing — the release is
+          // owned by this call site. released=true suppresses the fallback once ownership transfers
+          // to the Transaction.
+          var released = false
+          try {
+            withContext(outerContext) {
+              startTransactionCoroutine(
+                writeConnection = writer,
+                block = transaction,
+                onTransactionStarted = { released = true },
+              )
+            }
+          }
+          finally {
+            if(!released) {
               connectionPool.releaseWriterConnection()
             }
           }
@@ -111,8 +116,23 @@ internal class AndroidxSqliteExecutingDriver(
       // Past this point the Transaction owns the writer release via endTransaction.
       onTransactionStarted()
 
-      withContext(dispatcher + TransactionElement(transaction = transaction)) {
-        block()
+      // If CancellationException fires before block() starts, endTransaction is never called;
+      // release manually. Once blockStarted=true, endTransaction handles cleanup.
+      var blockStarted = false
+      try {
+        withContext(dispatcher + TransactionElement(transaction = transaction)) {
+          blockStarted = true
+          block()
+        }
+      } catch(t: Throwable) {
+        if(!blockStarted) {
+          try { writeConnection.execSQL("ROLLBACK") } catch(_: Throwable) {}
+          withContext(NonCancellable) {
+            activeTransaction = null
+            connectionPool.releaseWriterConnection()
+          }
+        }
+        throw t
       }
     }
   }
@@ -309,21 +329,23 @@ internal class AndroidxSqliteExecutingDriver(
       }
     }
 
-  private suspend inline fun <R> withConnection(
+  private suspend fun <R> withConnection(
     isWrite: Boolean,
-    block: SQLiteConnection.() -> R,
+    block: suspend SQLiteConnection.() -> R,
   ): R = when(val transaction = currentCoroutineContext()[TransactionElement]) {
     null -> {
-      val connection = when {
-        isWrite -> connectionPool.acquireWriterConnection()
-        else -> connectionPool.acquireReaderConnection()
-      }
-
-      try {
-        connection.block()
-      }
-      finally {
-        withContext(NonCancellable) {
+      val outerContext = currentCoroutineContext()
+      // Wrap acquire/release in NonCancellable to prevent CancellationException from deadlocking
+      // the mutex. outerContext is restored so the query body remains cancellable.
+      withContext(NonCancellable) {
+        val connection = when {
+          isWrite -> connectionPool.acquireWriterConnection()
+          else -> connectionPool.acquireReaderConnection()
+        }
+        try {
+          withContext(outerContext) { connection.block() }
+        }
+        finally {
           when {
             isWrite -> connectionPool.releaseWriterConnection()
             else -> connectionPool.releaseReaderConnection(connection)

--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/ConnectionPool.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/ConnectionPool.kt
@@ -7,6 +7,7 @@ import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConcurrencyModel.Mu
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConcurrencyModel.SingleReaderWriter
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -26,17 +27,15 @@ internal interface ConnectionPool : AutoCloseable {
   ): R
 }
 
-internal suspend inline fun <R> ConnectionPool.withWriterConnection(
-  block: SQLiteConnection.() -> R,
-): R {
+internal suspend fun <R> ConnectionPool.withWriterConnection(
+  block: suspend SQLiteConnection.() -> R,
+): R = withContext(NonCancellable) {
   val connection = acquireWriterConnection()
   try {
-    return connection.block()
+    connection.block()
   }
   finally {
-    withContext(NonCancellable) {
-      releaseWriterConnection()
-    }
+    releaseWriterConnection()
   }
 }
 
@@ -132,6 +131,26 @@ internal class AndroidxDriverConnectionPool(
   }
 
   /**
+   * Tries to acquire the writer connection within [timeoutMs], returning it or null on timeout.
+   *
+   * Uses tryLock() polling rather than lock() so the timeout is not defeated by NonCancellable,
+   * and because tryLock() is non-suspending there is no cancellation window while the lock is held.
+   */
+  private suspend fun tryAcquireWriterConnection(timeoutMs: Long = 50): SQLiteConnection? {
+    var locked = false
+    return try {
+      withTimeoutOrNull(timeoutMs) {
+        while(!writerMutex.tryLock()) delay(1)
+        locked = true
+      }
+      if(locked) writerConnection else null
+    } catch(t: Throwable) {
+      if(locked) writerMutex.unlock()
+      throw t
+    }
+  }
+
+  /**
    * Acquires a reader connection, suspending if none are available.
    * @return A reader SQLiteConnection
    */
@@ -140,11 +159,7 @@ internal class AndroidxDriverConnectionPool(
       if(concurrencyModel.readerCount == 0) return acquireWriterConnection()
       // acquire() returns null when capacity dropped to 0 mid-wait (e.g. WAL → non-WAL swap).
       // Loop so we re-check concurrencyModel and route to the writer.
-      val reader = readerPool.acquire(
-        onEmpty = {
-          withTimeoutOrNull(50) { acquireWriterConnection() }
-        },
-      )
+      val reader = readerPool.acquire(onEmpty = { tryAcquireWriterConnection() })
       if(reader != null) return reader
     }
   }
@@ -172,48 +187,51 @@ internal class AndroidxDriverConnectionPool(
   ): R = readerPool.withSwap(
     newCapacityAfter = { concurrencyModel.readerCount },
   ) {
-    val writer = acquireWriterConnection()
-    val previousConcurrencyModel = concurrencyModel as? MultipleReadersSingleWriter
-    var isConcurrencyModelReplaced = false
+    val outerContext = currentCoroutineContext()
+    // Wrap acquire/release in NonCancellable to prevent CancellationException from deadlocking the mutex.
+    // outerContext is restored for executeStatement so the caller's cancellation remains in effect.
+    withContext(NonCancellable) {
+      val writer = acquireWriterConnection()
+      val previousConcurrencyModel = concurrencyModel as? MultipleReadersSingleWriter
+      var isConcurrencyModelReplaced = false
 
-    try {
-      val isForeignKeyConstraintsEnabled =
-        writer.prepare("PRAGMA foreign_keys;").use { statement ->
-          statement.step()
-          statement.getBoolean(0)
+      try {
+        val isForeignKeyConstraintsEnabled =
+          writer.prepare("PRAGMA foreign_keys;").use { statement ->
+            statement.step()
+            statement.getBoolean(0)
+          }
+
+        val queryResult = withContext(outerContext) { executeStatement(writer) }
+
+        // PRAGMA journal_mode currently wipes out foreign_keys - https://issuetracker.google.com/issues/447613208
+        val foreignKeys = if(isForeignKeyConstraintsEnabled) "ON" else "OFF"
+        writer.execSQL("PRAGMA foreign_keys = $foreignKeys;")
+
+        if(previousConcurrencyModel != null) {
+          val result = when(queryResult) {
+            null -> null
+            is String -> queryResult
+            else -> error(
+              """
+              PRAGMA journal_mode is intercepted by AndroidxSqliteDriver to keep its connection pool
+              in sync with the database's journal mode, which requires the query result to be a String.
+              Got ${queryResult::class.simpleName ?: "<type unknown>"} instead. Either remove the custom
+              column adapter from this query, or set the journal mode via
+              AndroidxSqliteConfigurableDriver.setJournalMode in onConfigure.
+              """.trimIndent(),
+            )
+          }
+          val isWal = result.equals("wal", ignoreCase = true)
+          if(isWal != previousConcurrencyModel.isWal) {
+            concurrencyModel = previousConcurrencyModel.copy(isWal = isWal)
+            isConcurrencyModelReplaced = true
+          }
         }
 
-      val queryResult = executeStatement(writer)
-
-      // PRAGMA journal_mode currently wipes out foreign_keys - https://issuetracker.google.com/issues/447613208
-      val foreignKeys = if(isForeignKeyConstraintsEnabled) "ON" else "OFF"
-      writer.execSQL("PRAGMA foreign_keys = $foreignKeys;")
-
-      if(previousConcurrencyModel != null) {
-        val result = when(queryResult) {
-          null -> null
-          is String -> queryResult
-          else -> error(
-            """
-            PRAGMA journal_mode is intercepted by AndroidxSqliteDriver to keep its connection pool
-            in sync with the database's journal mode, which requires the query result to be a String.
-            Got ${queryResult::class.simpleName ?: "<type unknown>"} instead. Either remove the custom
-            column adapter from this query, or set the journal mode via
-            AndroidxSqliteConfigurableDriver.setJournalMode in onConfigure.
-            """.trimIndent(),
-          )
-        }
-        val isWal = result.equals("wal", ignoreCase = true)
-        if(isWal != previousConcurrencyModel.isWal) {
-          concurrencyModel = previousConcurrencyModel.copy(isWal = isWal)
-          isConcurrencyModelReplaced = true
-        }
+        queryResult
       }
-
-      queryResult
-    }
-    finally {
-      withContext(NonCancellable) {
+      finally {
         releaseWriterConnection()
         if(isConcurrencyModelReplaced) {
           try {


### PR DESCRIPTION
There are some cases where a poorly-timed job cancellation can prevent the writerMutex from being unlocked, forever locking DB writes (until app restart).
This wraps all acquisition/release of the mutex in NonCancellable (maintaining previous context for anything that isn't) and handles cases where the mutex might get abandoned before unlock.

We ran into this on https://github.com/mihonapp/mihon, where entering a screen to trigger a DB write and then backing out quickly would cause all further DB writes to stop working.
Tried extensively to reproduce the bug once this fix was in place, and couldn't, so I'm reasonably confident this should do the trick, but if this isn't the right way to handle it, this can be converted into an open issue about the DB deadlock instead.

Fair warning: Claude-assisted.

Leaving this in draft as I wasn't able to figure out a good way to make deterministic integration tests for this. One method would have involved including a dummy method that gets called before each point that got patched, allowing us to override that with something that throws CancellationException, but that seemed like a bit much.
Feel free to move out of draft if the test classes can wait until afterwards.