### PR TITLE
Fix writerMutex leaks on cancellation

### DIFF
--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
@@ -108,11 +108,34 @@ internal class AndroidxSqliteExecutingDriver(
       ).also {
         activeTransaction = it
       }
-      // Past this point the Transaction owns the writer release via endTransaction.
+      // BEGIN IMMEDIATE has now run. The Transaction's endTransaction releases the writer, but it
+      // only runs once block() starts (SqlDelight invokes it from block's finally). If cancellation
+      // fires at the withContext boundary before block() runs, endTransaction never executes, so we
+      // must roll back the open transaction and release the writer here. onTransactionStarted()
+      // tells the dispatch() call site to stop owning the release; blockStarted tracks whether that
+      // ownership has reached block() yet.
       onTransactionStarted()
 
-      withContext(dispatcher + TransactionElement(transaction = transaction)) {
-        block()
+      var blockStarted = false
+      try {
+        withContext(dispatcher + TransactionElement(transaction = transaction)) {
+          blockStarted = true
+          block()
+        }
+      }
+      finally {
+        // blockStarted only stays false if withContext threw before running block() — i.e.
+        // cancellation at the dispatch boundary, so this never runs on a normal return.
+        if(!blockStarted) {
+          withContext(NonCancellable) {
+            try {
+              writeConnection.execSQL("ROLLBACK")
+            }
+            catch(_: Throwable) {}
+            activeTransaction = null
+            connectionPool.releaseWriterConnection()
+          }
+        }
       }
     }
   }

--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/ConnectionPool.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/ConnectionPool.kt
@@ -7,6 +7,7 @@ import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConcurrencyModel.Mu
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConcurrencyModel.SingleReaderWriter
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -132,6 +133,36 @@ internal class AndroidxDriverConnectionPool(
   }
 
   /**
+   * Tries to acquire the writer within [timeoutMs], returning it or null on timeout.
+   *
+   * Uses non-suspending tryLock() polling rather than a suspending lock() wrapped in
+   * withTimeoutOrNull. A suspending acquire can complete (lock held) at the same instant the
+   * timeout fires, and withTimeoutOrNull's prompt cancellation would then discard the result while
+   * the lock stays held — leaking the writer forever. With tryLock() there is no window where the
+   * lock is acquired but the connection is thrown away.
+   */
+  private suspend fun tryAcquireWriterConnection(timeoutMs: Long = 50): SQLiteConnection? {
+    var locked = false
+    var handedOff = false
+    try {
+      withTimeoutOrNull(timeoutMs) {
+        while(!writerMutex.tryLock()) delay(1)
+        locked = true
+      }
+      if(!locked) return null
+      val connection = writerConnection
+      handedOff = true
+      return connection
+    }
+    finally {
+      // If the lock was taken but we're leaving without handing the connection to the caller —
+      // cancellation after tryLock() succeeded, or the lazy writerConnection initializer throwing —
+      // release it so the writer isn't leaked.
+      if(locked && !handedOff) writerMutex.unlock()
+    }
+  }
+
+  /**
    * Acquires a reader connection, suspending if none are available.
    * @return A reader SQLiteConnection
    */
@@ -141,9 +172,7 @@ internal class AndroidxDriverConnectionPool(
       // acquire() returns null when capacity dropped to 0 mid-wait (e.g. WAL → non-WAL swap).
       // Loop so we re-check concurrencyModel and route to the writer.
       val reader = readerPool.acquire(
-        onEmpty = {
-          withTimeoutOrNull(50) { acquireWriterConnection() }
-        },
+        onEmpty = { tryAcquireWriterConnection() },
       )
       if(reader != null) return reader
     }

--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/ReaderPool.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/ReaderPool.kt
@@ -27,7 +27,27 @@ internal class ReaderPool(
     val connection: Lazy<SQLiteConnection>,
   )
 
-  private val channel = Channel<ReaderEntry>(capacity = Channel.UNLIMITED)
+  // onUndeliveredElement: a receiver cancelled at the same instant a send resumes it (prompt
+  // cancellation) never sees the entry; without this handler the entry would be lost and the pool
+  // would permanently shrink, eventually hanging withSwap's drain and close(). Re-send it —
+  // trySend on an UNLIMITED channel only fails if the pool was closed, in which case the
+  // connection just needs to be closed like drainAndClose would have.
+  private val channel: Channel<ReaderEntry> = Channel(
+    capacity = Channel.UNLIMITED,
+    onUndeliveredElement = { entry ->
+      if(channel.trySend(entry).isFailure && entry.isCreated) {
+        val connection = entry.connection.value
+        try {
+          connection.close()
+        }
+        catch(_: Throwable) {}
+        try {
+          onConnectionClosed(connection)
+        }
+        catch(_: Throwable) {}
+      }
+    },
+  )
 
   private val swapMutex = Mutex()
 

--- a/library/src/commonTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
+++ b/library/src/commonTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -347,6 +348,44 @@ class AndroidxDriverConnectionPoolTest {
     pool.releaseWriterConnection()
 
     pool.releaseReaderConnection(fallbackReader!!)
+    pool.close()
+  }
+
+  @Test
+  fun `reader released to a cancelled acquire returns to the pool instead of being lost`() = runTest {
+    val pool = AndroidxDriverConnectionPool(
+      connectionFactory = TestConnectionFactory(),
+      nameProvider = { "test.db" },
+      isFileBased = true,
+      configuration = AndroidxSqliteConfiguration(
+        concurrencyModel = MultipleReadersSingleWriter(isWal = true, walCount = 1),
+      ),
+    )
+
+    // Drain the single reader and hold the writer so the acquire below parks on the channel.
+    val reader = pool.acquireReaderConnection()
+    pool.acquireWriterConnection()
+
+    val job = launch {
+      pool.acquireReaderConnection()
+    }
+
+    // Let the fallback time out and the acquire park on the reader channel.
+    delay(300)
+
+    // Release the reader — the send hands the entry straight to the parked acquire — then cancel
+    // the acquire before its resumption runs. Prompt cancellation discards the resumption, so
+    // without onUndeliveredElement the entry would be lost and the pool permanently shrunk.
+    pool.releaseReaderConnection(reader)
+    job.cancel()
+    job.join()
+
+    // The reader must still be acquirable; if the entry was lost this would time out.
+    val reacquired = withTimeoutOrNull(5_000) { pool.acquireReaderConnection() }
+    assertSame(reader, reacquired, "Reader handed to a cancelled acquire should return to the pool")
+
+    pool.releaseReaderConnection(reacquired!!)
+    pool.releaseWriterConnection()
     pool.close()
   }
 

--- a/library/src/commonTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
+++ b/library/src/commonTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
@@ -279,6 +279,77 @@ class AndroidxDriverConnectionPoolTest {
     }
   }
 
+  @Test
+  fun `reader fallback acquires the writer when the pool is empty and the writer is free`() = runTest {
+    val pool = AndroidxDriverConnectionPool(
+      connectionFactory = TestConnectionFactory(),
+      nameProvider = { "test.db" },
+      isFileBased = true,
+      configuration = AndroidxSqliteConfiguration(
+        concurrencyModel = MultipleReadersSingleWriter(isWal = true, walCount = 1),
+      ),
+    )
+
+    // Materialize the writer so we can compare identity, then free it.
+    val writer = pool.acquireWriterConnection()
+    pool.releaseWriterConnection()
+
+    // Drain the single reader so the pool is empty.
+    val reader = pool.acquireReaderConnection()
+
+    // With the pool empty and the writer free, the fallback hands out the writer as a reader.
+    val fallback = pool.acquireReaderConnection()
+    assertSame(writer, fallback, "Empty reader pool should fall back to the free writer")
+
+    pool.releaseReaderConnection(fallback)
+    pool.releaseReaderConnection(reader)
+    pool.close()
+  }
+
+  @Test
+  fun `reader fallback parks and recovers without leaking the writer when the writer is held`() = runTest {
+    val pool = AndroidxDriverConnectionPool(
+      connectionFactory = TestConnectionFactory(),
+      nameProvider = { "test.db" },
+      isFileBased = true,
+      configuration = AndroidxSqliteConfiguration(
+        concurrencyModel = MultipleReadersSingleWriter(isWal = true, walCount = 1),
+      ),
+    )
+
+    // Drain the single reader and hold the writer, so acquireReaderConnection's fallback times out
+    // instead of handing out the writer, and the acquire parks waiting for a reader to be released.
+    val reader = pool.acquireReaderConnection()
+    pool.acquireWriterConnection()
+
+    var acquired = false
+    var fallbackReader: SQLiteConnection? = null
+    val job = launch {
+      fallbackReader = pool.acquireReaderConnection()
+      acquired = true
+    }
+
+    // Let the fallback time out and park.
+    delay(300)
+    assertFalse(acquired, "Reader should stay parked while the pool is empty and the writer is held")
+
+    // Releasing the reader wakes the parked acquire.
+    pool.releaseReaderConnection(reader)
+    job.join()
+
+    assertTrue(acquired, "Parked reader should resume once a reader is released")
+    assertSame(reader, fallbackReader, "Released reader should be handed to the parked acquire")
+
+    // The fallback never took the writer, so a single release fully unlocks it; if a timed-out
+    // fallback had leaked the lock this re-acquire would suspend forever.
+    pool.releaseWriterConnection()
+    pool.acquireWriterConnection()
+    pool.releaseWriterConnection()
+
+    pool.releaseReaderConnection(fallbackReader!!)
+    pool.close()
+  }
+
   private class TestConnectionFactory : AndroidxSqliteConnectionFactory {
     override val driver = object : SQLiteDriver {
       override fun open(fileName: String): SQLiteConnection = TestConnection()


### PR DESCRIPTION
Alternative to #227 — the same targeted fixes, without the broad `NonCancellable` wrapping, plus a third leak that #227's blanket wrapping only covered incidentally.

## The two writer-mutex leaks

Both can leak the writer mutex permanently, wedging all writes until app restart.

**1. Reader-pool fallback discards an acquired lock.** `acquireReaderConnection`'s empty-pool fallback wrapped a *suspending* `acquireWriterConnection()` in `withTimeoutOrNull(50)`. If the writer frees right at the timeout boundary, `lock()` can complete (lock held) while `withTimeoutOrNull`'s prompt cancellation discards the returned connection — the classic [asynchronous-timeout-and-resources](https://kotlinlang.org/docs/cancellation-and-timeouts.html#asynchronous-timeout-and-resources) pitfall. Reachable under read contention.

Fixed with `tryAcquireWriterConnection()`, which polls non-suspending `tryLock()`, so there's no window where the lock is acquired but the connection is thrown away.

**2. Transaction ownership transfers before `block()` starts.** In `startTransactionCoroutine`, `BEGIN IMMEDIATE` runs in `Transaction.init`, then release ownership transfers to the transaction (`onTransactionStarted()`) — but the actual release runs in SqlDelight's `endTransaction`, which is only invoked once `block()` runs. Prompt cancellation at the `withContext` boundary before `block()` starts skips `endTransaction` entirely, leaking the writer and leaving the connection in an open transaction. (Matches the Mihon report: a write cancelled on navigation.)

Fixed by guarding that window: if cancelled before `block()` starts, `ROLLBACK` and release the writer.

## The reader-pool leak

`ReaderPool`'s channel had no `onUndeliveredElement` handler. A parked reader acquire cancelled at the same instant a `release()` resumes it never sees the entry — prompt cancellation discards the resumption and the `ReaderEntry` is silently lost. Each occurrence permanently shrinks the pool by one; lose them all and every read serializes through the writer fallback, and a later `setJournalMode` drain or `close()` hangs. Also plausible in the Mihon pattern (reads under contention cancelled on navigation).

Fixed with an `onUndeliveredElement` handler that re-sends the entry (the channel is `UNLIMITED`, so this only fails after close, in which case the connection is closed instead).

## Why not the broad `NonCancellable` wrapping from #227

The plain acquire/release paths (`dispatch`, `withConnection`, `setJournalMode`, `withWriterConnection`) are already correct:

- `Mutex.lock()` [releases the lock if cancelled after acquiring it](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.sync/-mutex/lock.html),
- every release already runs in `withContext(NonCancellable)`,
- there's no suspension point between `val c = acquire…()` and the `try {`, so the `finally` always runs.

Wrapping those acquires in `NonCancellable` adds context switches and makes a coroutine queued on the writer lock **non-cancellable while it waits** — a responsiveness regression. So this PR keeps only the surgical fixes.

## Tests

- Two deterministic regression tests for the reader-fallback path (happy fallback to a free writer; park-and-recover under writer contention with a no-leak re-acquire check).
- A deterministic regression test for the lost-reader-entry path (release racing a cancelled acquire; verified to fail without the `onUndeliveredElement` fix).
- `:library:jvmTest` green; `:library:detekt` clean.

Caveat: the exact cancellation races in the first two leaks aren't deterministically reproducible (same difficulty #227 hit). The protection here is structural — the racy patterns are removed rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)