### PR TITLE
Serialize WebConnectionPool connection access with a Mutex

### DIFF
--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
@@ -14,6 +14,7 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
@@ -124,9 +125,14 @@ internal class AndroidxSqliteExecutingDriver(
           try {
             writeConnection.executeSQL("ROLLBACK")
           }
+          catch(c: CancellationException) {
+            throw c
+          }
           catch(_: Throwable) {}
-          activeTransaction = null
-          connectionPool.releaseWriterConnection()
+          finally {
+            activeTransaction = null
+            connectionPool.releaseWriterConnection()
+          }
         }
       }
     }

--- a/library/src/nonWebTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
+++ b/library/src/nonWebTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -347,7 +348,7 @@ class AndroidxDriverConnectionPoolTest {
     pool.acquireWriterConnection()
     pool.releaseWriterConnection()
 
-    pool.releaseReaderConnection(fallbackReader!!)
+    pool.releaseReaderConnection(assertNotNull(fallbackReader))
     pool.close()
   }
 
@@ -384,7 +385,7 @@ class AndroidxDriverConnectionPoolTest {
     val reacquired = withTimeoutOrNull(5_000) { pool.acquireReaderConnection() }
     assertSame(reader, reacquired, "Reader handed to a cancelled acquire should return to the pool")
 
-    pool.releaseReaderConnection(reacquired!!)
+    pool.releaseReaderConnection(assertNotNull(reacquired))
     pool.releaseWriterConnection()
     pool.close()
   }

--- a/library/src/wasmJsTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteWebDriverTest.kt
+++ b/library/src/wasmJsTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteWebDriverTest.kt
@@ -6,6 +6,8 @@ import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.random.Random
 import kotlin.random.nextULong
@@ -117,6 +119,54 @@ class AndroidxSqliteWebDriverTest {
       assertEquals("persist", value)
       close()
     }
+  }
+
+  // Regression test for https://github.com/eygraber/sqldelight-androidx-driver/issues/195 —
+  // every web statement suspends across a worker round trip, so concurrent transactions
+  // interleave; without the WebConnectionPool mutex both issue BEGIN on the single connection
+  // ("cannot start a transaction within a transaction").
+  @Test
+  fun concurrentTransactionsDoNotInterleave() = runTest {
+    val driver = AndroidxSqliteDriver(
+      driver = webTestSqliteDriver(),
+      databaseType = AndroidxSqliteDatabaseType.Memory,
+      schema = schema,
+    )
+
+    val transacter = object : SuspendingTransacterImpl(driver) {}
+
+    val inserts = 10
+    coroutineScope {
+      repeat(inserts) { i ->
+        launch {
+          transacter.transaction {
+            driver.execute(null, "INSERT INTO test VALUES ($i, 'committed')", 0).await()
+          }
+        }
+        launch {
+          transacter.transaction {
+            driver.execute(null, "INSERT INTO test VALUES (${i + 1000}, 'rolled-back')", 0).await()
+            rollback()
+          }
+        }
+      }
+    }
+
+    val committedAndTotal = driver.executeQuery(
+      identifier = null,
+      sql = "SELECT COUNT(CASE WHEN value = 'committed' THEN 1 END), COUNT(*) FROM test",
+      mapper = { cursor ->
+        QueryResult.AsyncValue {
+          cursor.next().await()
+          requireNotNull(cursor.getLong(0)) to requireNotNull(cursor.getLong(1))
+        }
+      },
+      parameters = 0,
+    ).await()
+
+    assertEquals(inserts.toLong() to inserts.toLong(), committedAndTotal)
+
+    driver.close()
   }
 
   @Test

--- a/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteConcurrencyModel.web.kt
+++ b/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteConcurrencyModel.web.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @Suppress("InjectDispatcher")
 internal actual fun defaultIoDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
-// JS and wasmJs are single-threaded — limitedParallelism still serializes coroutines,
-// which is what the connection-pool concurrency model relies on.
+// Note: limitedParallelism bounds how many coroutines run between suspension points; it does
+// NOT make suspend-spanning sections atomic — a suspended coroutine yields its slot to the next
+// one. Nothing on web relies on it for mutual exclusion: WebConnectionPool never uses the
+// concurrency model's dispatcher and serializes connection use with a Mutex instead.
 @OptIn(ExperimentalCoroutinesApi::class)
 internal actual fun memoryOptimizedDispatcher(
   dispatcher: CoroutineDispatcher,

--- a/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/WebConnectionPool.web.kt
+++ b/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/WebConnectionPool.web.kt
@@ -4,11 +4,19 @@ import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.async.executeSQL
 import androidx.sqlite.async.prepare
 import androidx.sqlite.async.step
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
- * Single-connection pool used on JS/wasmJs. Web targets are single-threaded, so the
- * Mutex/Channel/swap-fence machinery in [AndroidxDriverConnectionPool] would only be wasted
- * coordination — readers, writers, and dispatchers all serialize naturally.
+ * Single-connection pool used on JS/wasmJs. Web targets are single-threaded, but not
+ * interleaving-free: every statement suspends across a web worker round trip, so two coroutines
+ * can interleave at any suspension point. All connection use is serialized through
+ * [connectionMutex] — otherwise concurrent transactions would both issue BEGIN on the single
+ * shared connection ("cannot start a transaction within a transaction"), and statements outside
+ * a transaction could run inside someone else's open transaction.
+ *
+ * Readers share the writer's lock because there is only one connection — this mirrors the
+ * `readerCount == 0` behavior of [AndroidxDriverConnectionPool].
  *
  * Both `createDefaultConnectionPool` and `createPassthroughConnectionPool` resolve to this
  * implementation on web.
@@ -20,8 +28,12 @@ internal class WebConnectionPool(
 ) : ConnectionPool {
   private val name by lazy { nameProvider() }
 
+  private val connectionMutex = Mutex()
+
   private var connection: SQLiteConnection? = null
 
+  // Must only be called while holding connectionMutex — createConnection and the PRAGMAs
+  // suspend, so an unguarded null-check would let two coroutines create two connections.
   private suspend fun acquire(): SQLiteConnection =
     connection ?: connectionFactory.createConnection(name).also {
       try {
@@ -46,17 +58,32 @@ internal class WebConnectionPool(
 
   override suspend fun <R> runOnDispatcher(block: suspend () -> R): R = block()
 
-  override suspend fun acquireWriterConnection(): SQLiteConnection = acquire()
+  override suspend fun acquireWriterConnection(): SQLiteConnection {
+    connectionMutex.lock()
+    return try {
+      acquire()
+    }
+    catch(t: Throwable) {
+      // If opening the connection or its PRAGMAs fail, release the mutex so future
+      // acquires aren't blocked forever.
+      connectionMutex.unlock()
+      throw t
+    }
+  }
 
-  override suspend fun releaseWriterConnection() {}
+  override suspend fun releaseWriterConnection() {
+    connectionMutex.unlock()
+  }
 
-  override suspend fun acquireReaderConnection(): SQLiteConnection = acquire()
+  override suspend fun acquireReaderConnection(): SQLiteConnection = acquireWriterConnection()
 
-  override suspend fun releaseReaderConnection(connection: SQLiteConnection) {}
+  override suspend fun releaseReaderConnection(connection: SQLiteConnection) {
+    connectionMutex.unlock()
+  }
 
   override suspend fun <R> setJournalMode(
     executeStatement: suspend (SQLiteConnection) -> R,
-  ): R {
+  ): R = connectionMutex.withLock {
     val c = acquire()
     val isForeignKeyConstraintsEnabled =
       c.prepare("PRAGMA foreign_keys;").use { statement ->
@@ -70,7 +97,7 @@ internal class WebConnectionPool(
     val foreignKeys = if(isForeignKeyConstraintsEnabled) "ON" else "OFF"
     c.executeSQL("PRAGMA foreign_keys = $foreignKeys;")
 
-    return queryResult
+    queryResult
   }
 
   override fun close() {


### PR DESCRIPTION
## Problem

Rapid-fire concurrent transactions on web crash with:

```
androidx.sqlite.SQLiteException: Error code: 1, message: cannot start a transaction within a transaction
```

Reported in https://github.com/eygraber/sqldelight-androidx-driver/issues/195#issuecomment-4747295705.

`WebConnectionPool` had no mutual exclusion — its class comment reasoned that web targets are single-threaded so "readers, writers, and dispatchers all serialize naturally". That holds for threads, but not for coroutines: on web every statement suspends across a worker round trip, so a second coroutine can start its own transaction while the first is suspended mid-`BEGIN IMMEDIATE`, on the same shared connection.

The missing lock also meant:
- non-transactional statements acquired the connection while another coroutine's transaction was open, silently running inside it (lost on rollback, reads of uncommitted state)
- concurrent first use raced the lazy `acquire()` — two connections created, one leaked

## Fix

Serialize all connection use through a suspending `Mutex`, mirroring the `readerCount == 0` behavior of `AndroidxDriverConnectionPool`:

- `acquireWriterConnection()` locks (unlocking on failure so a failed open doesn't wedge the pool)
- readers share the writer's lock since there is only one connection
- `setJournalMode` runs under `withLock`

No reentrancy hazard: statements inside a transaction take the connection from the `TransactionElement` in the coroutine context and never re-acquire, and nested transactions reuse the enclosing one.

## Test

New `concurrentTransactionsDoNotInterleave` regression test: 20 concurrent coroutines (10 committing transactions, 10 rolling back), asserting exactly the committed rows survive. Verified it fails on the unfixed pool with the exact error from the issue, and passes with the fix (wasmJs headless Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR

This is the first PR to run `detektAll` against the `web` branch, so it surfaced pre-existing findings, fixed in the second commit:

- `SuspendFunSwallowedCancellation` in the transaction-cancellation rollback path — `CancellationException` is now rethrown, with the cleanup moved to a `finally` so the writer is still released
- two `UnsafeCallOnNullableType` in `AndroidxDriverConnectionPoolTest` (replaced with `assertNotNull`)
- corrected the comment in `AndroidxSqliteConcurrencyModel.web.kt` that claimed `limitedParallelism` provides serialization the pool relies on — it bounds concurrency between suspension points but does not make suspend-spanning sections atomic, and nothing on web uses it for mutual exclusion
