### PR TITLE
Fix pause/resume races in the OPFS worker

### DIFF
--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
@@ -14,6 +14,7 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
@@ -124,9 +125,14 @@ internal class AndroidxSqliteExecutingDriver(
           try {
             writeConnection.executeSQL("ROLLBACK")
           }
+          catch(c: CancellationException) {
+            throw c
+          }
           catch(_: Throwable) {}
-          activeTransaction = null
-          connectionPool.releaseWriterConnection()
+          finally {
+            activeTransaction = null
+            connectionPool.releaseWriterConnection()
+          }
         }
       }
     }

--- a/library/src/nonWebTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
+++ b/library/src/nonWebTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxDriverConnectionPoolTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -347,7 +348,7 @@ class AndroidxDriverConnectionPoolTest {
     pool.acquireWriterConnection()
     pool.releaseWriterConnection()
 
-    pool.releaseReaderConnection(fallbackReader!!)
+    pool.releaseReaderConnection(assertNotNull(fallbackReader))
     pool.close()
   }
 
@@ -384,7 +385,7 @@ class AndroidxDriverConnectionPoolTest {
     val reacquired = withTimeoutOrNull(5_000) { pool.acquireReaderConnection() }
     assertSame(reader, reacquired, "Reader handed to a cancelled acquire should return to the pool")
 
-    pool.releaseReaderConnection(reacquired!!)
+    pool.releaseReaderConnection(assertNotNull(reacquired))
     pool.releaseWriterConnection()
     pool.close()
   }

--- a/library/src/wasmJsTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteWebDriverTest.kt
+++ b/library/src/wasmJsTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteWebDriverTest.kt
@@ -6,6 +6,8 @@ import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.random.Random
 import kotlin.random.nextULong
@@ -117,6 +119,54 @@ class AndroidxSqliteWebDriverTest {
       assertEquals("persist", value)
       close()
     }
+  }
+
+  // Regression test for https://github.com/eygraber/sqldelight-androidx-driver/issues/195 —
+  // every web statement suspends across a worker round trip, so concurrent transactions
+  // interleave; without the WebConnectionPool mutex both issue BEGIN on the single connection
+  // ("cannot start a transaction within a transaction").
+  @Test
+  fun concurrentTransactionsDoNotInterleave() = runTest {
+    val driver = AndroidxSqliteDriver(
+      driver = webTestSqliteDriver(),
+      databaseType = AndroidxSqliteDatabaseType.Memory,
+      schema = schema,
+    )
+
+    val transacter = object : SuspendingTransacterImpl(driver) {}
+
+    val inserts = 10
+    coroutineScope {
+      repeat(inserts) { i ->
+        launch {
+          transacter.transaction {
+            driver.execute(null, "INSERT INTO test VALUES ($i, 'committed')", 0).await()
+          }
+        }
+        launch {
+          transacter.transaction {
+            driver.execute(null, "INSERT INTO test VALUES (${i + 1000}, 'rolled-back')", 0).await()
+            rollback()
+          }
+        }
+      }
+    }
+
+    val committedAndTotal = driver.executeQuery(
+      identifier = null,
+      sql = "SELECT COUNT(CASE WHEN value = 'committed' THEN 1 END), COUNT(*) FROM test",
+      mapper = { cursor ->
+        QueryResult.AsyncValue {
+          cursor.next().await()
+          requireNotNull(cursor.getLong(0)) to requireNotNull(cursor.getLong(1))
+        }
+      },
+      parameters = 0,
+    ).await()
+
+    assertEquals(inserts.toLong() to inserts.toLong(), committedAndTotal)
+
+    driver.close()
   }
 
   @Test

--- a/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteConcurrencyModel.web.kt
+++ b/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteConcurrencyModel.web.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 @Suppress("InjectDispatcher")
 internal actual fun defaultIoDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
-// JS and wasmJs are single-threaded — limitedParallelism still serializes coroutines,
-// which is what the connection-pool concurrency model relies on.
+// Note: limitedParallelism bounds how many coroutines run between suspension points; it does
+// NOT make suspend-spanning sections atomic — a suspended coroutine yields its slot to the next
+// one. Nothing on web relies on it for mutual exclusion: WebConnectionPool never uses the
+// concurrency model's dispatcher and serializes connection use with a Mutex instead.
 @OptIn(ExperimentalCoroutinesApi::class)
 internal actual fun memoryOptimizedDispatcher(
   dispatcher: CoroutineDispatcher,

--- a/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/WebConnectionPool.web.kt
+++ b/library/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/WebConnectionPool.web.kt
@@ -4,11 +4,19 @@ import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.async.executeSQL
 import androidx.sqlite.async.prepare
 import androidx.sqlite.async.step
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
- * Single-connection pool used on JS/wasmJs. Web targets are single-threaded, so the
- * Mutex/Channel/swap-fence machinery in [AndroidxDriverConnectionPool] would only be wasted
- * coordination — readers, writers, and dispatchers all serialize naturally.
+ * Single-connection pool used on JS/wasmJs. Web targets are single-threaded, but not
+ * interleaving-free: every statement suspends across a web worker round trip, so two coroutines
+ * can interleave at any suspension point. All connection use is serialized through
+ * [connectionMutex] — otherwise concurrent transactions would both issue BEGIN on the single
+ * shared connection ("cannot start a transaction within a transaction"), and statements outside
+ * a transaction could run inside someone else's open transaction.
+ *
+ * Readers share the writer's lock because there is only one connection — this mirrors the
+ * `readerCount == 0` behavior of [AndroidxDriverConnectionPool].
  *
  * Both `createDefaultConnectionPool` and `createPassthroughConnectionPool` resolve to this
  * implementation on web.
@@ -20,8 +28,12 @@ internal class WebConnectionPool(
 ) : ConnectionPool {
   private val name by lazy { nameProvider() }
 
+  private val connectionMutex = Mutex()
+
   private var connection: SQLiteConnection? = null
 
+  // Must only be called while holding connectionMutex — createConnection and the PRAGMAs
+  // suspend, so an unguarded null-check would let two coroutines create two connections.
   private suspend fun acquire(): SQLiteConnection =
     connection ?: connectionFactory.createConnection(name).also {
       try {
@@ -46,17 +58,32 @@ internal class WebConnectionPool(
 
   override suspend fun <R> runOnDispatcher(block: suspend () -> R): R = block()
 
-  override suspend fun acquireWriterConnection(): SQLiteConnection = acquire()
+  override suspend fun acquireWriterConnection(): SQLiteConnection {
+    connectionMutex.lock()
+    return try {
+      acquire()
+    }
+    catch(t: Throwable) {
+      // If opening the connection or its PRAGMAs fail, release the mutex so future
+      // acquires aren't blocked forever.
+      connectionMutex.unlock()
+      throw t
+    }
+  }
 
-  override suspend fun releaseWriterConnection() {}
+  override suspend fun releaseWriterConnection() {
+    connectionMutex.unlock()
+  }
 
-  override suspend fun acquireReaderConnection(): SQLiteConnection = acquire()
+  override suspend fun acquireReaderConnection(): SQLiteConnection = acquireWriterConnection()
 
-  override suspend fun releaseReaderConnection(connection: SQLiteConnection) {}
+  override suspend fun releaseReaderConnection(connection: SQLiteConnection) {
+    connectionMutex.unlock()
+  }
 
   override suspend fun <R> setJournalMode(
     executeStatement: suspend (SQLiteConnection) -> R,
-  ): R {
+  ): R = connectionMutex.withLock {
     val c = acquire()
     val isForeignKeyConstraintsEnabled =
       c.prepare("PRAGMA foreign_keys;").use { statement ->
@@ -70,7 +97,7 @@ internal class WebConnectionPool(
     val foreignKeys = if(isForeignKeyConstraintsEnabled) "ON" else "OFF"
     c.executeSQL("PRAGMA foreign_keys = $foreignKeys;")
 
-    return queryResult
+    queryResult
   }
 
   override fun close() {

--- a/opfs-driver/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/OpfsWorker.kt
+++ b/opfs-driver/src/webMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/OpfsWorker.kt
@@ -47,6 +47,12 @@ public enum class OpfsMultiTabMode {
    * Trade-offs: queries from non-owner tabs incur a cross-tab message round-trip, and in-flight
    * transactions on the owner tab are not preserved if it closes mid-transaction (the new owner
    * starts with fresh connections).
+   *
+   * Ownership transfer is at-least-once: requests that never received a response from the old
+   * owner are retried against the new one. If the old owner executed a write but closed before
+   * responding, the retry executes that write a second time. Statements whose duplicate
+   * execution matters should be written idempotently (e.g. `INSERT OR IGNORE`, explicit
+   * primary keys, or upserts).
    */
   Shared,
 

--- a/opfs-worker-impl/src/jsMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/worker/Sqlite.kt
+++ b/opfs-worker-impl/src/jsMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/worker/Sqlite.kt
@@ -1,10 +1,19 @@
 package com.eygraber.sqldelight.androidx.driver.opfs.worker
 
+private var localSqliteInitInFlight = false
+private val localSqliteInitWaiters = mutableListOf<Pair<() -> Unit, (dynamic) -> Unit>>()
+
+// Single-flight: the import/install chain is asynchronous, so a second call arriving while the
+// first is in flight must join it instead of starting a second chain (which would install the
+// SAH pool VFS twice).
 internal fun ensureLocalSqlite(onDone: () -> Unit, onError: (dynamic) -> Unit) {
   if(poolUtil != null) {
     onDone()
     return
   }
+  localSqliteInitWaiters.add(onDone to onError)
+  if(localSqliteInitInFlight) return
+  localSqliteInitInFlight = true
   if(sqlite3 == null) {
     val sqlite3Url: String = initData.sqlite3Url.unsafeCast<String>()
     val wasmUrl: String = initData.wasmUrl.unsafeCast<String>()
@@ -15,17 +24,31 @@ internal fun ensureLocalSqlite(onDone: () -> Unit, onError: (dynamic) -> Unit) {
           installSqlite3(mod, wasmUrl),
           { factory ->
             sqlite3 = factory
-            installPool(0, onDone, onError)
+            installPool(0, ::finishLocalSqliteInitSuccess, ::finishLocalSqliteInitFailure)
           },
-          onError,
+          ::finishLocalSqliteInitFailure,
         )
       },
-      onError,
+      ::finishLocalSqliteInitFailure,
     )
   }
   else {
-    installPool(0, onDone, onError)
+    installPool(0, ::finishLocalSqliteInitSuccess, ::finishLocalSqliteInitFailure)
   }
+}
+
+private fun finishLocalSqliteInitSuccess() {
+  localSqliteInitInFlight = false
+  val waiters = localSqliteInitWaiters.toList()
+  localSqliteInitWaiters.clear()
+  waiters.forEach { (onDone, _) -> onDone() }
+}
+
+private fun finishLocalSqliteInitFailure(err: dynamic) {
+  localSqliteInitInFlight = false
+  val waiters = localSqliteInitWaiters.toList()
+  localSqliteInitWaiters.clear()
+  waiters.forEach { (_, onError) -> onError(err) }
 }
 
 private fun installPool(attempt: Int, onDone: () -> Unit, onError: (dynamic) -> Unit) {

--- a/opfs-worker-impl/src/jsMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/worker/WorkerMain.kt
+++ b/opfs-worker-impl/src/jsMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/worker/WorkerMain.kt
@@ -41,11 +41,43 @@ private fun routeDriverMessage(e: MessageEventLike) {
     forwardToLeader(requestMsg.id, requestMsg.data)
     return
   }
-  if(isPaused) {
+  if(pauseState != PauseState.Live) {
     pausedQueue.add(e)
     return
   }
   dispatchLocal(requestMsg.id, requestMsg.data)
+}
+
+// The resume chain finished claiming handles. If a pause arrived mid-chain, release them
+// again and only now ack — the orchestrator holds the Web Lock until the ack arrives.
+private fun onResumeSettled() {
+  if(pendingPause) {
+    pendingPause = false
+    pauseState = PauseState.Paused
+    suspendLocalInstances()
+    try {
+      poolPauseVfs(poolUtil)
+    }
+    catch(err: Throwable) {
+      consoleErrorWith("sqldelight-androidx-opfs-worker: pauseVfs failed", err)
+    }
+    controlPort?.let(::controlPortAck)
+    return
+  }
+  pauseState = PauseState.Live
+  while(pausedQueue.isNotEmpty()) {
+    routeDriverMessage(pausedQueue.removeAt(0))
+  }
+}
+
+// The resume chain failed, so no handles are held. Stay paused; if a pause arrived mid-chain,
+// ack it now so the orchestrator can release the Web Lock.
+private fun onResumeFailed() {
+  pauseState = PauseState.Paused
+  if(pendingPause) {
+    pendingPause = false
+    controlPort?.let(::controlPortAck)
+  }
 }
 
 private fun onMessage(e: MessageEventLike) {
@@ -61,7 +93,7 @@ private fun onMessage(e: MessageEventLike) {
       }
       "PauseOnHidden" -> {
         // Don't claim SAH handles until the main thread tells us we have the foreground lock.
-        isPaused = true
+        pauseState = PauseState.Paused
         return
       }
       else -> {
@@ -80,8 +112,16 @@ private fun onMessage(e: MessageEventLike) {
     return
   }
   if(isObject(data) && isObject(data.__opfsPause)) {
-    if(multiTabMode == "PauseOnHidden" && !isPaused) {
-      isPaused = true
+    if(multiTabMode == "PauseOnHidden" && pauseState == PauseState.Resuming) {
+      // The resume chain is mid-flight and will claim SAH handles when it settles. Defer the
+      // pause work AND the ack until then — the orchestrator releases the Web Lock on ack, and
+      // releasing it before our handles are actually released would let another tab claim the
+      // pool while we're claiming it too.
+      pendingPause = true
+      return
+    }
+    if(multiTabMode == "PauseOnHidden" && pauseState == PauseState.Live) {
+      pauseState = PauseState.Paused
       if(poolUtil != null) {
         suspendLocalInstances()
         try {
@@ -96,27 +136,24 @@ private fun onMessage(e: MessageEventLike) {
     return
   }
   if(isObject(data) && isObject(data.__opfsResume)) {
-    if(multiTabMode == "PauseOnHidden" && isPaused) {
-      val drain: () -> Unit = {
-        isPaused = false
-        while(pausedQueue.isNotEmpty()) {
-          routeDriverMessage(pausedQueue.removeAt(0))
-        }
-      }
+    if(multiTabMode == "PauseOnHidden" && pauseState == PauseState.Paused) {
+      pauseState = PauseState.Resuming
       if(poolUtil == null) {
         ensureLocalSqlite(
-          onDone = drain,
+          onDone = ::onResumeSettled,
           onError = { err ->
             consoleErrorWith("sqldelight-androidx-opfs-worker: failed to initialize sqlite3", err)
+            onResumeFailed()
           },
         )
       }
       else {
         thenAccept(
           unpauseVfs(poolUtil),
-          { drain() },
+          { onResumeSettled() },
           { err ->
             consoleErrorWith("sqldelight-androidx-opfs-worker: unpauseVfs failed", err)
+            onResumeFailed()
           },
         )
       }
@@ -128,7 +165,7 @@ private fun onMessage(e: MessageEventLike) {
     return
   }
   if(multiTabMode == "PauseOnHidden") {
-    if(isPaused) pausedQueue.add(e) else routeDriverMessage(e)
+    if(pauseState != PauseState.Live) pausedQueue.add(e) else routeDriverMessage(e)
     return
   }
   if(sqlite3 == null) {

--- a/opfs-worker-impl/src/jsMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/worker/WorkerState.kt
+++ b/opfs-worker-impl/src/jsMain/kotlin/com/eygraber/sqldelight/androidx/driver/opfs/worker/WorkerState.kt
@@ -31,7 +31,17 @@ internal val followerStates = mutableMapOf<String, dynamic>()
 internal val queuedDriverMessages = mutableListOf<MessageEventLike>()
 internal var acceptingDriverMessages = false
 
-internal var isPaused = false
+// PauseOnHidden lifecycle. Resuming is a real state, not a detail: the resume chain
+// (sqlite init / unpauseVfs) is asynchronous, and both pause and resume messages that arrive
+// mid-chain need to be handled against it, not against Paused/Live.
+internal enum class PauseState { Live, Resuming, Paused }
+
+internal var pauseState = PauseState.Live
+
+// A __opfsPause arrived while the resume chain was in flight. The pause work and its ack are
+// deferred until the chain settles — see onResumeSettled/onResumeFailed in WorkerMain.
+internal var pendingPause = false
+
 internal val pausedQueue = mutableListOf<MessageEventLike>()
 
 // Shared connections live until the worker terminates; followers may still reference them.


### PR DESCRIPTION
Follow-up to #245 — second batch of fixes from auditing the web code for invariants that span an async boundary.

## Bug 1: pause during an in-flight resume releases the Web Lock while SAH handles are (about to be) held

The worker's pause/resume protocol modeled only two states (`isPaused`), but resuming is an asynchronous intermediate state: the `__opfsResume` handler kicks off a promise chain (`ensureLocalSqlite` or `unpauseVfs`) and `isPaused` stays `true` until it settles.

If the tab went hidden mid-resume, the `__opfsPause` handler saw `isPaused == true`, skipped the pause work — **but still sent the ack**. The `PauseOnHiddenOrchestrator` releases the Web Lock on that ack (its whole invariant is "don't release until the worker's handles are released"), so:

1. another tab acquires the lock and claims the SAH pool
2. our resume chain completes, drains the queue, and claims handles too
3. two workers fight over exclusive OPFS sync access handles

`Resuming` is now an explicit state. A pause arriving during it sets `pendingPause` and defers both the pause work and the ack until the chain settles: on success the freshly claimed handles are released first, then the ack is sent; on failure no handles are held, so it just acks. Messages continue to queue in any non-`Live` state.

## Bug 2: `ensureLocalSqlite` double-init

No single-flight guard — a second call while the import/install chain was in flight started a second chain, installing the SAH pool VFS twice (reachable exactly via bug 1's ack → lock release → re-acquire → second resume). Concurrent callers now register as waiters and join the in-flight init.

## Testing

`:opfs-worker-impl:check` and the full wasmJs browser suite pass (the OPFS tests exercise the worker end-to-end in Single mode). The pause/resume race itself needs multi-tab visibility choreography that headless CI can't drive deterministically, so that path is verified by protocol walkthrough: pause-while-paused still acks idempotently, resume-while-resuming is ignored, and a failed resume stays paused while still acking any deferred pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR

Documents Shared mode's at-least-once failover semantics on the `OpfsMultiTabMode.Shared` KDoc: requests that never got a response from a closing owner are retried against the new owner, so a write the old owner executed but didn't acknowledge can run twice — statements where that matters should be idempotent.

Stacked on #245.
