### PR TITLE
Confine currentTransaction() to the transaction's owner thread

### DIFF
--- a/library/src/androidMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.android.kt
+++ b/library/src/androidMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.android.kt
@@ -1,0 +1,4 @@
+package com.eygraber.sqldelight.androidx.driver
+
+@Suppress("DEPRECATION")
+internal actual fun currentThreadId(): Long = Thread.currentThread().id

--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteExecutingDriver.kt
@@ -32,6 +32,11 @@ internal data class TransactionElement(
   companion object Key : CoroutineContext.Key<TransactionElement>
 }
 
+private class ActiveTransaction(
+  val ownerThreadId: Long,
+  val transaction: Transacter.Transaction,
+)
+
 internal class AndroidxSqliteExecutingDriver(
   private val connectionPool: ConnectionPool,
   private val isStatementCacheSkipped: Boolean,
@@ -40,7 +45,7 @@ internal class AndroidxSqliteExecutingDriver(
   private val statementCacheSize: Int,
 ) : SqlDriver, SuspendingTransacter.TransactionDispatcher {
   @Volatile
-  private var activeTransaction: Transacter.Transaction? = null
+  private var activeTransaction: ActiveTransaction? = null
 
   override suspend fun <R> dispatch(transaction: suspend () -> R) =
     when(val enclosing = currentCoroutineContext()[TransactionElement]) {
@@ -105,8 +110,16 @@ internal class AndroidxSqliteExecutingDriver(
       val transaction = Transaction(
         enclosingTransaction = null,
         connection = writeConnection,
-      ).also {
-        activeTransaction = it
+      ).also { newTransaction ->
+        // The transaction (and everything SqlDelight does with it, including reading its
+        // pendingTables during postTransactionCleanup) is confined to this thread for its entire
+        // lifetime. Recording the owner thread lets currentTransaction() hide the transaction from
+        // other threads — SqlDelight's notifyQueries would otherwise mutate the transaction's
+        // unsynchronized pendingTables from a concurrent coroutine while cleanup reads it.
+        activeTransaction = ActiveTransaction(
+          ownerThreadId = currentThreadId(),
+          transaction = newTransaction,
+        )
       }
       // BEGIN IMMEDIATE has now run. The Transaction's endTransaction releases the writer, but it
       // only runs once block() starts (SqlDelight invokes it from block's finally). If cancellation
@@ -149,7 +162,8 @@ internal class AndroidxSqliteExecutingDriver(
       }.transaction
     }
 
-  override fun currentTransaction(): Transacter.Transaction? = activeTransaction
+  override fun currentTransaction(): Transacter.Transaction? =
+    activeTransaction?.takeIf { it.ownerThreadId == currentThreadId() }?.transaction
 
   override fun <R> executeQuery(
     identifier: Int?,

--- a/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.kt
+++ b/library/src/commonMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.kt
@@ -1,0 +1,6 @@
+package com.eygraber.sqldelight.androidx.driver
+
+/**
+ * Returns an identifier for the current thread that is unique among all live threads.
+ */
+internal expect fun currentThreadId(): Long

--- a/library/src/commonTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteTransacterTest.kt
+++ b/library/src/commonTest/kotlin/com/eygraber/sqldelight/androidx/driver/AndroidxSqliteTransacterTest.kt
@@ -1,13 +1,16 @@
 package com.eygraber.sqldelight.androidx.driver
 
 import androidx.sqlite.SQLiteConnection
+import app.cash.sqldelight.Query
 import app.cash.sqldelight.SuspendingTransacterImpl
 import app.cash.sqldelight.db.AfterVersion
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
@@ -19,6 +22,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -363,6 +367,60 @@ abstract class AndroidxSqliteTransacterTest {
       scope = { transactionWithResult(false, it) },
       block = { rollback(Unit) },
     )
+  }
+
+  @Test
+  fun `currentTransaction is not visible to threads other than the transaction thread`() = runTest {
+    val transactionActive = CompletableDeferred<Unit>()
+    val isTransactionVisibleElsewhere = CompletableDeferred<Boolean>()
+
+    val observer = launch(IoDispatcher) {
+      transactionActive.await()
+      isTransactionVisibleElsewhere.complete(driver.currentTransaction() != null)
+    }
+
+    transacter.transaction {
+      assertNotNull(driver.currentTransaction())
+      transactionActive.complete(Unit)
+      assertFalse(
+        isTransactionVisibleElsewhere.await(),
+        "A thread that isn't running the transaction must not see it",
+      )
+      assertNotNull(driver.currentTransaction())
+    }
+
+    observer.join()
+    assertNull(driver.currentTransaction())
+  }
+
+  @Test
+  fun `a write from another coroutine during a transaction notifies its listeners immediately`() = runTest {
+    val transactionActive = CompletableDeferred<Unit>()
+    val notified = CompletableDeferred<Unit>()
+
+    val notifyingTransacter = object : SuspendingTransacterImpl(driver) {
+      fun notifyTestQueries() = notifyQueries(identifier = 1) { emit -> emit("test") }
+    }
+
+    driver.addListener(
+      "test",
+      listener = Query.Listener { notified.complete(Unit) },
+    )
+
+    val notifier = launch(IoDispatcher) {
+      transactionActive.await()
+      notifyingTransacter.notifyTestQueries()
+    }
+
+    transacter.transaction {
+      transactionActive.complete(Unit)
+      // If the notifying coroutine were to see this transaction as its own, the notification
+      // would be buffered into this transaction's pendingTables instead of firing, and this
+      // await would never complete.
+      notified.await()
+    }
+
+    notifier.join()
   }
 }
 

--- a/library/src/jvmMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.jvm.kt
+++ b/library/src/jvmMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.jvm.kt
@@ -1,0 +1,4 @@
+package com.eygraber.sqldelight.androidx.driver
+
+@Suppress("DEPRECATION")
+internal actual fun currentThreadId(): Long = Thread.currentThread().id

--- a/library/src/nativeMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.native.kt
+++ b/library/src/nativeMain/kotlin/com/eygraber/sqldelight/androidx/driver/CurrentThreadId.native.kt
@@ -1,0 +1,13 @@
+package com.eygraber.sqldelight.androidx.driver
+
+import kotlinx.atomicfu.atomic
+import kotlin.native.concurrent.ThreadLocal
+
+private val nextThreadId = atomic(0L)
+
+@ThreadLocal
+private object CurrentThreadId {
+  val id: Long = nextThreadId.incrementAndGet()
+}
+
+internal actual fun currentThreadId(): Long = CurrentThreadId.id


### PR DESCRIPTION
Fixes #255.

### Problem

`currentTransaction()` returned the `@Volatile activeTransaction` field unconditionally, so SqlDelight's `notifyQueries` running in a concurrent coroutine could resolve another coroutine's in-flight transaction and mutate its unsynchronized `pendingTables` while `postTransactionCleanup` reads it via `toTypedArray()` — crashing with `ConcurrentModificationException` / `ArrayIndexOutOfBoundsException` (details and production stack traces in #255).

### Approach

`dispatch` already confines a transaction — and everything SqlDelight does with it, including `postTransactionCleanup` — to a single thread for its entire lifetime via the `runBlocking` trick, so thread identity is exactly the right visibility scope for `currentTransaction()`:

- The active transaction is stored together with its owner thread id (`ActiveTransaction`), and `currentTransaction()` returns it only when called from that thread.
- Any other thread now sees `null`, so its `notifyQueries` notifies listeners immediately (correct for an auto-committed write) instead of buffering into a foreign transaction, where the notification was deferred to that transaction's commit or dropped on its rollback.
- `currentThreadId()` is a new `internal expect fun`: `Thread.currentThread().id` on JVM/Android, and an atomicfu counter in a `@ThreadLocal` object on native (no posix interop, works uniformly across all native targets).

It stays a per-driver-instance field (rather than, say, a global `@ThreadLocal` holder) so transactions can't bleed across driver instances, and the existing internal reader in `AndroidxSqliteDriverHolder` (which runs inside the migration transaction, on its thread) keeps working unchanged.

### Testing

Two regression tests in `AndroidxSqliteTransacterTest`, both fail against the previous implementation:

- `currentTransaction is not visible to threads other than the transaction thread` — direct visibility check from a concurrent coroutine while a transaction is active.
- `a write from another coroutine during a transaction notifies its listeners immediately` — behavioral check that a concurrent notification fires instead of being swallowed into the foreign transaction (deadlocks with the old code).

Ran locally: `:library:jvmTest`, `:library:macosArm64Test`, `:library:testAndroidHostTest`, `:library:detektAll`, `:library:assemble` (all targets), `./format --no-format`.
